### PR TITLE
Add gRPC dev libraries to Spot C++ SDK debian deps

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -320,7 +320,7 @@ if (UNIX)
   set(CPACK_PACKAGE_NAME "spot-cpp-sdk")
   set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
   set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcli11-dev (>=2.1.2)")  # libcli11-dev is header-only, thus it has to be listed explicitly
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcli11-dev (>=2.1.2), libgrpc++-dev (>=1.30.2)")  # not picked up by shlibdeps, thus listed explicitly
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Boston Dynamics SDK Publisher <bd-sdk-publisher@bostondynamics.com>")
   set(CPACK_PACKAGE_VENDOR "Boston Dynamics")
   set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
Follow-up to #5. `shlibdeps` was missing another library.