### PR TITLE
Add Protobuf dev libraries to Spot C++ SDK debian deps

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -320,7 +320,7 @@ if (UNIX)
   set(CPACK_PACKAGE_NAME "spot-cpp-sdk")
   set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
   set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcli11-dev (>=2.1.2), libgrpc++-dev (>=1.30.2)")  # not picked up by shlibdeps, thus listed explicitly
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "libcli11-dev (>=2.1.2), libgrpc++-dev (>=1.30.2), libprotobuf-dev (>=3.12.4)")  # not picked up by shlibdeps, thus listed explicitly
   set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Boston Dynamics SDK Publisher <bd-sdk-publisher@bostondynamics.com>")
   set(CPACK_PACKAGE_VENDOR "Boston Dynamics")
   set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})


### PR DESCRIPTION
Follow-up to the follow-up #6. `shlibdeps` turned out to be much less useful than anticipated.