### PR TITLE
Source release `bosdyn` 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Development Kit License (20191101-BDSDK-SL).
 
 # Spot C++ SDK (BETA) in ROS 2
 
-**This is fork of [`boston-dynamics/spot-cpp-sdk`](https://github.com/boston-dynamics/spot-cpp-sdk) patched for ROS 2 release. Proceed upstream for any inquiry or request.**
+**This is a fork of [`boston-dynamics/spot-cpp-sdk`](https://github.com/boston-dynamics/spot-cpp-sdk) patched for ROS 2 release. Proceed upstream for any inquiry or request.**
 
 Develop applications and payloads for Spot using the Boston Dynamics Spot C++ SDK. The Spot C++ SDK is a **beta** release.
 

--- a/cpp/CHANGELOG.rst
+++ b/cpp/CHANGELOG.rst
@@ -1,0 +1,86 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package bosdyn
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Prepare for ROS 2 release (`#10 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/10>`_)
+* Patch for ROS 2 release (`#9 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/9>`_)
+* Add Protobuf dev libraries to Spot C++ SDK debian deps (`#8 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/8>`_)
+* No CONFIG modules in Spot C++ SDK CMake config (`#7 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/7>`_)
+* Add gRPC dev libraries to Spot C++ SDK debian deps (`#6 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/6>`_)
+* Add dependencies to Spot C++ SDK debians (`#5 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/5>`_)
+* Update devcontainers for building debians (`#4 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/4>`_)
+* Contributors: Andrew Messing, Michel Hidalgo
+
+4.1.0 (2024-09-25)
+------------------
+* Merge branch 'boston-dynamics:master' into master
+* Release v4.1.0 of Boston Dynamics Spot SDK
+* Release v4.0.3 of Boston Dynamics Spot SDK
+* Contributors: Andrew Messing, Boston Dynamics SDK Publisher
+
+4.0.2 (2024-06-05)
+------------------
+* Merge branch 'boston-dynamics:master' into master
+* Release v4.0.2 of Boston Dynamics Spot SDK
+* Added CD GHA
+* Contributors: Andrew Messing, Boston Dynamics SDK Publisher
+
+4.0.0 (2024-02-23)
+------------------
+* Added CD GHA
+* Release v4.0.0 of Boston Dynamics Spot SDK
+* Contributors: Andrew Messing, Boston Dynamics SDK Publisher
+
+4.0.0 (2024-02-12)
+------------------
+
+3.3.2 (2023-09-18)
+------------------
+
+3.3.1 (2023-08-28)
+------------------
+* Release v3.3.1 of Boston Dynamics Spot SDK
+* Contributors: Boston Dynamics SDK Publisher
+
+3.3.0 (2023-06-07)
+------------------
+* Release v3.3.0 of Boston Dynamics Spot SDK
+* Contributors: Boston Dynamics SDK Publisher
+
+3.2.3 (2023-04-03)
+------------------
+
+3.2.2 (2023-02-13)
+------------------
+* Release v3.2.2 of Boston Dynamics Spot SDK
+* Contributors: Boston Dynamics SDK Publisher
+
+3.2.1 (2022-10-31)
+------------------
+
+3.2.0 (2022-08-23)
+------------------
+* Release v3.2.0 of Boston Dynamics Spot SDK
+* Contributors: Boston Dynamics SDK Publisher
+
+3.1.2 (2022-05-26)
+------------------
+
+3.1.1 (2022-05-02)
+------------------
+
+3.1.0 (2022-02-22)
+------------------
+* Release v3.1.0 of Boston Dynamics Spot SDK
+* Contributors: Boston Dynamics SDK Publisher
+
+3.0.3 (2021-12-07)
+------------------
+
+3.0.2 (2021-11-19)
+------------------
+* Fixed windows build issues
+* Release v3.0.2 of Boston Dynamics Spot SDK
+* Contributors: Boston Dynamics SDK Publisher

--- a/cpp/CHANGELOG.rst
+++ b/cpp/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package bosdyn
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+4.1.0 (2024-12-03)
+------------------
 * Prepare for ROS 2 release (`#10 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/10>`_)
 * Patch for ROS 2 release (`#9 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/9>`_)
 * Add Protobuf dev libraries to Spot C++ SDK debian deps (`#8 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/8>`_)
@@ -11,18 +11,12 @@ Forthcoming
 * Add gRPC dev libraries to Spot C++ SDK debian deps (`#6 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/6>`_)
 * Add dependencies to Spot C++ SDK debians (`#5 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/5>`_)
 * Update devcontainers for building debians (`#4 <https://github.com/bdaiinstitute/spot-cpp-sdk/issues/4>`_)
-* Contributors: Andrew Messing, Michel Hidalgo
-
-4.1.0 (2024-09-25)
-------------------
-* Merge branch 'boston-dynamics:master' into master
 * Release v4.1.0 of Boston Dynamics Spot SDK
 * Release v4.0.3 of Boston Dynamics Spot SDK
-* Contributors: Andrew Messing, Boston Dynamics SDK Publisher
+* Contributors: Andrew Messing, Boston Dynamics SDK Publisher, Michel Hidalgo
 
 4.0.2 (2024-06-05)
 ------------------
-* Merge branch 'boston-dynamics:master' into master
 * Release v4.0.2 of Boston Dynamics Spot SDK
 * Added CD GHA
 * Contributors: Andrew Messing, Boston Dynamics SDK Publisher


### PR DESCRIPTION
This patch adds package changelogs and pushes ROS 2 patches under the 4.1.0 version in preparation for the first binary release.